### PR TITLE
update Jessie repository https://unix.stackexchange.com/a/508728

### DIFF
--- a/odoo/Dockerfile
+++ b/odoo/Dockerfile
@@ -1,5 +1,8 @@
 FROM camptocamp/odoo-project:10.0-3.1.1-batteries
 
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list \
+    && sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list \
+    && echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf;
 RUN apt-get update \
     && apt-get install -y --no-install-recommends vim wget git
 


### PR DESCRIPTION
see https://unix.stackexchange.com/a/508728
and https://unix.stackexchange.com/a/508948

without this docky build fails with 404 errors when trying to install the deb packages (wget, vim and git)

cc @sebastienbeau 