### PR TITLE
based on odoo-project:10.0-3.1.2-batteries to avoid 404 repo issues

### DIFF
--- a/odoo/Dockerfile
+++ b/odoo/Dockerfile
@@ -1,4 +1,4 @@
-FROM camptocamp/odoo-project:10.0-3.1.1-batteries
+FROM camptocamp/odoo-project:10.0-3.1.2-batteries
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends vim wget git


### PR DESCRIPTION
fixes issue describded in https://github.com/akretion/docker-odoo-shopinvader/pull/7 in a clean manner
